### PR TITLE
Add tests to run against JSONPath Compliance Test Suite

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/jsonpath-compliance-test-suite"]
+	path = test/jsonpath-compliance-test-suite
+	url = https://github.com/jsonpath-standard/jsonpath-compliance-test-suite.git

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gemspec
+
+group :development, :test do
+  gem 'rake'
+  gem 'abnftt'
+  gem 'minitest'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,33 @@
+PATH
+  remote: .
+  specs:
+    jpt (0.1.4)
+      neatjson (~> 0.10)
+      ostruct (~> 0)
+      treetop (~> 1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    abnftt (0.2.9)
+    minitest (5.25.4)
+    neatjson (0.10.5)
+    ostruct (0.6.1)
+    polyglot (0.3.5)
+    rake (13.2.1)
+    treetop (1.6.14)
+      polyglot (~> 0.3)
+
+PLATFORMS
+  arm64-darwin-23
+  ruby
+
+DEPENDENCIES
+  abnftt
+  bundler (~> 2)
+  jpt!
+  minitest
+  rake
+
+BUNDLED WITH
+   2.6.5

--- a/Rakefile
+++ b/Rakefile
@@ -20,3 +20,6 @@ end
 task :linetest => :build do
   sh "bin/jpt -l test-data/test.jpl"
 end
+
+require "minitest/test_task"
+Minitest::TestTask.create

--- a/jpt.gemspec
+++ b/jpt.gemspec
@@ -13,8 +13,9 @@ Gem::Specification.new do |s|
 
   s.require_paths = ["lib"]
 
-  s.add_development_dependency 'bundler', '~>1'
+  s.add_development_dependency 'bundler', '~>2'
   s.add_dependency 'treetop', '~>1'
+  s.add_dependency 'ostruct', '~>0'
 #  s.add_dependency 'json'
   s.add_dependency 'neatjson', '~>0.10'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,4 @@
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+require "jpt"
+
+require "minitest/autorun"

--- a/test/test_jpt.rb
+++ b/test/test_jpt.rb
@@ -5,18 +5,25 @@ require "json"
 describe JPT do
   JSON.parse(File.read("test/jsonpath-compliance-test-suite/cts.json")).fetch("tests").each do |test|
     name = test["name"]
+    selector = test.fetch("selector")
 
-    it "test: #{name.inspect}" do
-      if test.key?("result")
-        result = JPT.from_jp(test.fetch("selector")).apply(test["document"])
-        assert_equal(result, test["result"])
-      elsif test["invalid_selector"]
+    if test["invalid_selector"]
+      it "fails with invalid selector #{selector.inspect} (#{name.inspect})" do
         # Should this really raise? – Some "invalid selectors" just work.
         assert_raises do
-          JPT.from_jp(test.fetch("selector"))
+          JPT.from_jp(selector)
         end
+      end
+      next
+    end
+
+    it "queries #{selector.inspect} (#{name.inspect})" do
+      document = test["document"]
+      if test.key?("result")
+        result = JPT.from_jp(selector).apply(document)
+        assert_equal(result, test["result"])
       elsif test.key?("results")
-        result = JPT.from_jp(test.fetch("selector")).apply(test["document"])
+        result = JPT.from_jp(selector).apply(document)
         assert_includes(test["results"], result)
       else
         raise "don't know how to test #{name} – #{test.inspect}"

--- a/test/test_jpt.rb
+++ b/test/test_jpt.rb
@@ -1,0 +1,26 @@
+require "minitest/spec"
+require "test_helper"
+require "json"
+
+describe JPT do
+  JSON.parse(File.read("test/jsonpath-compliance-test-suite/cts.json")).fetch("tests").each do |test|
+    name = test["name"]
+
+    it "test: #{name.inspect}" do
+      if test.key?("result")
+        result = JPT.from_jp(test.fetch("selector")).apply(test["document"])
+        assert_equal(result, test["result"])
+      elsif test["invalid_selector"]
+        # Should this really raise? – Some "invalid selectors" just work.
+        assert_raises do
+          JPT.from_jp(test.fetch("selector"))
+        end
+      elsif test.key?("results")
+        result = JPT.from_jp(test.fetch("selector")).apply(test["document"])
+        assert_includes(test["results"], result)
+      else
+        raise "don't know how to test #{name} – #{test.inspect}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
See also https://github.com/cabo/jpt/issues/1

This adds tests to test against the [JSONPath test suite](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite).

This PR adds a Gemfile with required libraries to make the tests pass.

The tests can be run with `bundle exec rake test`
